### PR TITLE
Generic model, serializer and filter backends.

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -1,18 +1,12 @@
-import uuid
-
 from django.db import models
-
-class EventKind(models.Model):
-    uuid = models.UUIDField(default=uuid.uuid4, editable=False)
-    name = models.CharField(max_length=250)
-    
-    def __str__(self):
-        return self.name
+from forzaboard.models import UUIDModel
 
 
-class Event(models.Model):
-    uuid = models.UUIDField(default=uuid.uuid4, editable=False)
-    name = models.CharField(max_length=250)
+class EventKind(UUIDModel):
+    pass
+
+
+class Event(UUIDModel):
     location = models.ForeignKey(
         'Location',
         on_delete=models.CASCADE,
@@ -22,14 +16,9 @@ class Event(models.Model):
         on_delete=models.CASCADE,
     )
     active = models.BooleanField()
-    
-    def __str__(self):
-        return self.name
 
 
-class Location(models.Model):
-    uuid = models.UUIDField(default=uuid.uuid4, editable=False)
-    name = models.CharField(max_length=250)
+class Location(UUIDModel):
     x = models.IntegerField()
     y = models.IntegerField()
     main_event = models.ForeignKey(
@@ -39,6 +28,3 @@ class Location(models.Model):
         null=True,
         blank=True
     )
-    
-    def __str__(self):
-        return self.name

--- a/events/serializers.py
+++ b/events/serializers.py
@@ -1,20 +1,22 @@
-from rest_framework import serializers
 from events.models import Event, EventKind, Location
+from forzaboard.serializers import UUIDRelatedField, UUIDModelSerializer
 
 
-class EventKindSerializer(serializers.ModelSerializer):
+class EventKindSerializer(UUIDModelSerializer):
     class Meta:
         model = EventKind
-        fields = ['uuid', 'name']
 
 
-class EventSerializer(serializers.ModelSerializer):
+class EventSerializer(UUIDModelSerializer):
+
     class Meta:
         model = Event
-        fields = ['uuid', 'name', 'location', 'kind', 'active']
+        fields = ['location', 'kind', 'active']
 
 
-class LocationSerializer(serializers.ModelSerializer):
+class LocationSerializer(UUIDModelSerializer):
+    serializer_related_field = UUIDRelatedField
+
     class Meta:
         model = Location
-        fields = ['uuid', 'name', 'x', 'y', 'main_event']
+        fields = ['x', 'y', 'main_event']

--- a/forzaboard/filters.py
+++ b/forzaboard/filters.py
@@ -1,0 +1,21 @@
+from django.core.exceptions import FieldError
+from rest_framework import filters
+from rest_framework.exceptions import ValidationError
+
+
+class GenericRESTFilterBackend(filters.BaseFilterBackend):
+    """
+    Filter that only allows users to see their own objects.
+    """
+    def filter_queryset(self, request, queryset, view):
+        query_kwargs = {}
+        for field, value in request.query_params.items():
+            if field == 'ordering':
+                continue
+            query_kwargs[field] = value
+        try:
+            return queryset.filter(**query_kwargs)
+        except ValueError:
+            raise ValidationError("Invalid value for query")
+        except FieldError:
+            raise ValidationError("Invalid field for query")

--- a/forzaboard/models.py
+++ b/forzaboard/models.py
@@ -1,0 +1,13 @@
+import uuid
+from django.db import models
+
+
+class UUIDModel(models.Model):
+    uuid = models.UUIDField(default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=250)
+
+    class Meta:
+        abstract = True
+
+    def __str__(self):
+        return self.name

--- a/forzaboard/serializers.py
+++ b/forzaboard/serializers.py
@@ -1,0 +1,39 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+from forzaboard.models import UUIDModel
+
+
+class UUIDRelatedField(serializers.RelatedField):
+
+    default_error_messages = {
+        'required': _('This field is required.'),
+        'does_not_exist': _('Object with uuid={value} does not exist.'),
+        'invalid': _('Invalid value.'),
+    }
+
+    def to_internal_value(self, data):
+        queryset = self.get_queryset()
+        try:
+            return queryset.get(uuid=data)
+        except ObjectDoesNotExist:
+            self.fail('does_not_exist', value=data)
+        except (TypeError, ValueError):
+            self.fail('invalid')
+
+    def to_representation(self, value):
+        return value.uuid
+
+
+class UUIDModelSerializer(serializers.ModelSerializer):
+    serializer_related_field = UUIDRelatedField
+
+    def get_field_names(self, *args, **kwargs):
+        fields = super().get_field_names(*args, **kwargs)
+        Meta = getattr(self, 'Meta', None)
+        model = getattr(Meta, 'model', None)
+        assert hasattr(model, 'uuid'), 'Model must have a "uuid" field'
+        assert hasattr(model, 'name'), 'Model must have a "name" field'
+        assert issubclass(model, UUIDModel), 'Model must be subclass of forzaboard.UUIDModel'
+
+        return fields + ['uuid', 'name']

--- a/forzaboard/settings.py
+++ b/forzaboard/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'corsheaders',
     'rest_framework',
+    'forzaboard',
     'forza_auth',
     'events',
     'leaderboards',
@@ -163,5 +164,9 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+    ],
+    'DEFAULT_FILTER_BACKENDS': [
+        'forzaboard.filters.GenericRESTFilterBackend',
+        'rest_framework.filters.OrderingFilter'
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ dj-database-url==0.5.0
 Django==3.2.9
 django-cockroachdb==3.2.2
 django-cors-headers==3.10.1
-django-filter==21.1
 djangorestframework==3.12.4
 djangorestframework-simplejwt==5.0.0
 gunicorn==20.1.0


### PR DESCRIPTION
Add generic models and serializers for that will always have uuid and name as fields and always represent the model instances with the name.

The serializer will also make sure relationships are presented as UUID instead of PK.

The filter backend allows filtering using url queries mimicking the django queryset api. `name=<name>` or normal filtering or `location__uuid=<uuid>` to follow relationships.

There is also an ordering backend. `?ordering=<field_name>`. Use '-' to invert the order.